### PR TITLE
Add PDF to DOCX conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # codex-yann
+
+This repository contains utilities for converting PDF files to DOCX.
+
+## Usage
+
+Install dependencies (fitz/PyMuPDF, python-docx, Pillow, pytesseract, opencv-python) and run:
+
+```bash
+python pdf2docx.py --input example.pdf --output example.docx [--ocr] [--no-images] [--verbose]
+```
+
+The `--ocr` option enables text extraction from scanned pages using Tesseract. Images can be ignored with `--no-images`. Verbose output prints parsing information.

--- a/docx_builder.py
+++ b/docx_builder.py
@@ -1,0 +1,19 @@
+from io import BytesIO
+from docx import Document
+from docx.shared import Inches
+
+
+def build_docx(pages, output_path):
+    """Build a DOCX file from parsed PDF pages."""
+    document = Document()
+    for page_index, items in enumerate(pages):
+        for item in items:
+            if item.get("type") == "text":
+                document.add_paragraph(item.get("text", ""))
+            elif item.get("type") == "image":
+                image_bytes = item.get("data")
+                if image_bytes:
+                    document.add_picture(BytesIO(image_bytes), width=Inches(6))
+        if page_index != len(pages) - 1:
+            document.add_page_break()
+    document.save(output_path)

--- a/pdf2docx.py
+++ b/pdf2docx.py
@@ -1,0 +1,21 @@
+import argparse
+
+from pdf_parser import parse_pdf
+from docx_builder import build_docx
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert PDF files to DOCX")
+    parser.add_argument("--input", required=True, help="Input PDF file")
+    parser.add_argument("--output", required=True, help="Output DOCX file")
+    parser.add_argument("--ocr", action="store_true", help="Use OCR on scanned pages")
+    parser.add_argument("--no-images", action="store_true", help="Ignore images in output")
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+    args = parser.parse_args()
+
+    pages = parse_pdf(args.input, ocr=args.ocr, no_images=args.no_images, verbose=args.verbose)
+    build_docx(pages, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -1,0 +1,38 @@
+import fitz
+from PIL import Image
+import pytesseract
+from io import BytesIO
+
+
+def parse_pdf(path, ocr=False, no_images=False, verbose=False):
+    """Parse PDF and return list of pages with text and image data."""
+    doc = fitz.open(path)
+    pages = []
+    for page_index in range(len(doc)):
+        page = doc[page_index]
+        items = []
+        # Extract text blocks and images using PyMuPDF
+        blocks = page.get_text("dict")["blocks"]
+        for block in blocks:
+            if block["type"] == 0:  # text
+                text = block.get("text", "").strip()
+                if text:
+                    items.append({"type": "text", "text": text})
+            elif block["type"] == 1 and not no_images:
+                xref = block.get("xref")
+                if xref:
+                    base_image = doc.extract_image(xref)
+                    if base_image:
+                        image_bytes = base_image.get("image")
+                        items.append({"type": "image", "data": image_bytes})
+        # If no text detected and OCR is requested, run Tesseract
+        if ocr and not any(i["type"] == "text" for i in items):
+            pix = page.get_pixmap()
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            ocr_text = pytesseract.image_to_string(img)
+            if ocr_text.strip():
+                items.append({"type": "text", "text": ocr_text})
+        if verbose:
+            print(f"Parsed page {page_index + 1} with {len(items)} items")
+        pages.append(items)
+    return pages


### PR DESCRIPTION
## Summary
- add README instructions for PDF to DOCX conversion
- implement `pdf_parser` using PyMuPDF and Tesseract
- implement `docx_builder` for assembling a DOCX
- add `pdf2docx.py` CLI to glue parser and builder together

## Testing
- `python -m py_compile pdf_parser.py docx_builder.py pdf2docx.py main.py`
- `python pdf2docx.py --help` *(fails: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68594d6763648328a6f22f482113e4c7